### PR TITLE
disallow blocked users from the system

### DIFF
--- a/lib/t_web/controllers/mobile_auth_controller.ex
+++ b/lib/t_web/controllers/mobile_auth_controller.ex
@@ -3,11 +3,13 @@ defmodule TWeb.MobileAuthController do
   alias TWeb.UserAuth
   alias T.Accounts
 
+  # TODO test blocked flow
   def verify_apple_id(conn, %{"token" => base64_id_token}) do
     id_token = Base.decode64!(base64_id_token)
 
     case Accounts.login_or_register_user_with_apple_id(id_token) do
       {:ok, %Accounts.User{} = user} -> verification_success_response(conn, user)
+      {:error, :blocked} -> send_resp(conn, 403, [])
       {:error, _reason} -> send_resp(conn, 400, [])
     end
   end

--- a/test/t/accounts/blocking_test.exs
+++ b/test/t/accounts/blocking_test.exs
@@ -63,7 +63,7 @@ defmodule T.Accounts.BlockingTest do
 
     test "blocks the user", %{user: user} do
       refute Repo.get!(Accounts.User, user.id).blocked_at
-      assert :ok == Accounts.block_user(user.id)
+      assert {:ok, _changes} = Accounts.block_user(user.id)
       assert Repo.get!(Accounts.User, user.id).blocked_at
     end
 
@@ -76,7 +76,7 @@ defmodule T.Accounts.BlockingTest do
       Matches.subscribe_for_user(user.id)
       Matches.subscribe_for_user(other.id)
 
-      assert :ok == Accounts.block_user(user.id)
+      assert {:ok, _changes} = Accounts.block_user(user.id)
 
       assert_receive {Matches, :unmatched, ^match_id}
 
@@ -86,7 +86,7 @@ defmodule T.Accounts.BlockingTest do
 
     test "blocked user is hidden", %{user: user} do
       assert Repo.get!(Accounts.Profile, user.id).hidden? == false
-      assert :ok == Accounts.block_user(user.id)
+      assert {:ok, _changes} = Accounts.block_user(user.id)
       assert Repo.get!(Accounts.Profile, user.id).hidden? == true
     end
   end


### PR DESCRIPTION
Right now blocked users can access the system (they can log in, connect to socket, etc.). This PRs removes that ability.

Scenario 1, user is blocked while online

1. [`Accounts.block_user/1`](https://github.com/getsince/test3/blob/9c9d1fb921fa6aeca6785d31b7ca175fbf14a08a/lib/t/accounts.ex#L202-L233) is called that blocks the user and removes all session tokens
2. At the call site of `Accounts.block_user/1`, [session tokens are iterated and for each connected socket `disconnect` command is sent](https://github.com/getsince/test3/blob/9c9d1fb921fa6aeca6785d31b7ca175fbf14a08a/lib/t_web/live/profile/index.ex#L64-L70)
3. Blocked user disconnects from backend, [iOS tries to reconnect, gets 403 in response, and proceeds to log out](https://github.com/getsince/test5/blob/ff8211776fc35b824db69f64b888ac79ff264630/Since/Auth/AuthedCoordinator.swift#L36-L39) like in [test4](https://github.com/getsince/test4/blob/05f4914289839a038feda3dd0e68dabe39f48873/Since/App/AppCoordinator.swift#L99-L102)
4. On sign-in-with-apple screen user tries to log in, [gets 403 response again,](https://github.com/getsince/test3/blob/9c9d1fb921fa6aeca6785d31b7ca175fbf14a08a/lib/t_web/controllers/mobile_auth_controller.ex#L12) this time meaning that their account is no longer active and iOS shows a banner with support contacts

Scenario 2, user is blocked while offline

1. [`Accounts.block_user/1`](https://github.com/getsince/test3/blob/9c9d1fb921fa6aeca6785d31b7ca175fbf14a08a/lib/t/accounts.ex#L202-L233) is called that blocks the user and removes all session tokens
2. When connecting to the socket some time later, [ios gets 403 response for the provided token, proceeds to log out](https://github.com/getsince/test5/blob/ff8211776fc35b824db69f64b888ac79ff264630/Since/Auth/AuthedCoordinator.swift#L36-L39)
3. same as `4.` in scenario 1