### PR TITLE
fix sentry errors for new apns

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -67,7 +67,6 @@ if config_env() == :prod do
     room_id: System.fetch_env!("TG_ROOM_ID") |> String.to_integer()
 
   config :t, APNS,
-    default_topic: System.fetch_env!("APNS_TOPIC"),
     keys: [
       %{
         key: System.fetch_env!("SANDBOX_APNS_KEY"),
@@ -84,6 +83,8 @@ if config_env() == :prod do
         env: :prod
       }
     ]
+
+  config :t, T.PushNotifications.APNS, default_topic: System.fetch_env!("APNS_TOPIC")
 
   config :t, run_migrations_on_start?: true
 
@@ -128,7 +129,6 @@ if config_env() == :dev do
   config :logger, T.PubSubLoggerBackend, level: :debug
 
   config :t, APNS,
-    default_topic: System.fetch_env!("APNS_TOPIC"),
     keys: [
       %{
         key: System.fetch_env!("SANDBOX_APNS_KEY"),
@@ -145,6 +145,8 @@ if config_env() == :dev do
         env: :prod
       }
     ]
+
+  config :t, T.PushNotifications.APNS, default_topic: System.fetch_env!("APNS_TOPIC")
 
   config :t, T.Twilio,
     account_sid: System.fetch_env!("TWILIO_ACCOUNT_SID"),

--- a/lib/t/push_notifications/apns.ex
+++ b/lib/t/push_notifications/apns.ex
@@ -44,14 +44,7 @@ defmodule T.PushNotifications.APNS do
   defp build_call_notification(device, payload) do
     %PushKitDevice{device_id: device_id, topic: topic} = device
     topic = topic || default_topic()
-
-    APNS.build_notification(
-      device_id,
-      topic <> ".voip",
-      payload,
-      apns_env(device),
-      _type = "voip"
-    )
+    APNS.build_notification(device_id, topic, payload, apns_env(device), _type = "voip")
   end
 
   # alerts

--- a/test/t_web/channels/feed_channel_test.exs
+++ b/test/t_web/channels/feed_channel_test.exs
@@ -667,7 +667,7 @@ defmodule TWeb.FeedChannelTest do
       # ABABABAB on prod -> fails!
       |> expect(:push, fn %{env: :prod} = n ->
         assert n.device_id == "ABABABAB"
-        assert n.topic == "app.topic.voip"
+        assert n.topic == "app.topic"
         assert n.push_type == "voip"
         assert n.payload["caller_id"] == me.id
         assert n.payload["caller_name"] == "that"
@@ -677,7 +677,7 @@ defmodule TWeb.FeedChannelTest do
       # BABABABABA on sandbox -> fails!
       |> expect(:push, fn %{env: :dev} = n ->
         assert n.device_id == "BABABABABA"
-        assert n.topic == "app.topic.voip"
+        assert n.topic == "app.topic"
         assert n.push_type == "voip"
         assert n.payload["caller_id"] == me.id
         assert n.payload["caller_name"] == "that"


### PR DESCRIPTION
@akhrail1996 I get ~~two~~ three error notifications from sentry, this PR fixes them. I also patched backend with the same fixes, so I'll keep this PR open for now to wait for more errors.